### PR TITLE
Replace encode/decodestring() with encode/decodebytes()

### DIFF
--- a/atest/resources/Util.py
+++ b/atest/resources/Util.py
@@ -21,7 +21,7 @@ class Util(object):
         """`nonce` should be Base64 encoded."""
         token = self._get_autousernametoken()
         token.autosetnonce = False
-        token.setnonce(base64.decodestring(nonce.encode('UTF-8')))
+        token.setnonce(base64.decodebytes(nonce.encode('UTF-8')))
 
     def set_fixed_created(self, created):
         """Set a fixed value for the created element.

--- a/src/Suds2Library/wsse.py
+++ b/src/Suds2Library/wsse.py
@@ -105,7 +105,7 @@ class AutoUsernameToken(UsernameToken):
             n = Element('Nonce', ns=WSSENS)
             if not self.digest:
                 self.nonce = self.nonce.encode('UTF-8')
-            n.setText(base64.encodestring(self.nonce)[:-1])
+            n.setText(base64.encodebytes(self.nonce)[:-1])
             n.set('EncodingType', BASE64_ENC_TYPE)
             root.append(n)
         if self.created:
@@ -119,7 +119,7 @@ class AutoUsernameToken(UsernameToken):
         created = iso_utc(self.created) if self.created else ""
         password = str(self.password)
         message = nonce + created + password
-        return base64.encodestring(sha1(message.encode('UTF-8')).digest())[:-1]
+        return base64.encodebytes(sha1(message.encode('UTF-8')).digest())[:-1]
 
 
 class _WsseKeywords(object):


### PR DESCRIPTION
From 3.9 version of python encodestring() and decodestring() have been removed from base64 package, being replaced by encodebytes() and decodebytes().